### PR TITLE
Fix process video py3 9 6

### DIFF
--- a/process_video.py
+++ b/process_video.py
@@ -27,4 +27,4 @@ if __name__ == '__main__':
 
     p_out = Path(args.output)
     p_out.mkdir(parents=True, exist_ok=True)
-    run_on_video(args.video, args.masks, args.output)
+    run_on_video(args.video, args.masks, args.output, frames_with_masks)

--- a/util/image_saver.py
+++ b/util/image_saver.py
@@ -245,6 +245,17 @@ class ParallelImageSaver:
         self._object_color = overlay_color_if_b_and_w
         self._finished = Value('b', False)
 
+    def __getstate__(self):
+        # To solve issue in python 3.9.6 of multiprocessing.Process instances are unserializable
+        # capture what is normally pickled
+        state = self.__dict__.copy()
+
+        # remove unpicklable/problematic variables
+        # (multiprocessing.Process in this case)
+        state['_mask_saver_worker'] = None
+        state['_overlay_saver_worker'] = None
+        return state
+    
     def save_mask(self, mask: Image.Image, frame_name: str):
         self._mask_queue.put((mask, frame_name, 'masks', '.png'))
 


### PR DESCRIPTION
Fixing issue of using 'process_video' with Python 3.9.6.
1. Fixing issue of 'process_video' only using default first mask frame as input. Now 'frame_with_masks' is forwarded.
2. Adding '__getstate__' to ParallelImageSaver to solve issue in Python 3.9.6 of multiprocessing.Process instances not being serializable, and fixing issue of 'process_video' ending with "typeerror cannot pickle 'weakref' object" exception.

Fixes #5 